### PR TITLE
Dev PR 7C: Attempt 2 fix for wrong GCC usage.

### DIFF
--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -7,13 +7,19 @@ on:
             - "main"
 
 jobs:
-    my-job:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - name: Enable Utility
-              run: chmod +x ./utility.sh
-            - name: Build Code
-              run: ./utility.sh debug
-            - name: Do Tests
-              run: ./utility.sh test
+  my-job:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        gcc-version: [13]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup
+        env:
+          CC: gcc-${{matrix.gcc-version}}
+          CXX: g++-${{matrix.gcc-version}}
+        run: chmod +x ./utility.sh
+      - name: Build Code
+        run: ./utility.sh debug
+      - name: Do Tests
+        run: ./utility.sh test

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -15,10 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup
-        env:
-          CC: gcc-${{matrix.gcc-version}}
-          CXX: g++-${{matrix.gcc-version}}
-        run: chmod +x ./utility.sh
+        run: update-alternatives --set gcc gcc-${{matrix.gcc-version}} && update-alternatives --set g++ g++-${{matrix.gcc-version}} && chmod +x ./utility.sh
       - name: Build Code
         run: ./utility.sh debug
       - name: Do Tests


### PR DESCRIPTION
This is attempt 2 for fixing the issue where `g++` still defaults to GCC 11 in the Actions workflow. I have added commands that should override `g++-11` with `g++-13`.